### PR TITLE
Compatibility with new version of Vec.jl

### DIFF
--- a/src/2d/features/features.jl
+++ b/src/2d/features/features.jl
@@ -120,7 +120,7 @@ function Base.get(::Feature_RoadEdgeDist_Left, rec::SceneRecord, roadway::Roadwa
     roadproj = proj(footpoint, lane, roadway)
     curvept = roadway[RoadIndex(roadproj)]
     lane = roadway[roadproj.tag]
-    FeatureValue(lane.width/2 + abs(curvept.pos - footpoint) - offset)
+    FeatureValue(lane.width/2 + norm(VecE2(curvept.pos - footpoint)) - offset)
 end
 generate_feature_functions("RoadEdgeDist_Right", :d_edger, Float64, "m")
 function Base.get(::Feature_RoadEdgeDist_Right, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
@@ -132,7 +132,7 @@ function Base.get(::Feature_RoadEdgeDist_Right, rec::SceneRecord, roadway::Roadw
     roadproj = proj(footpoint, lane, roadway)
     curvept = roadway[RoadIndex(roadproj)]
     lane = roadway[roadproj.tag]
-    FeatureValue(lane.width/2 + abs(curvept.pos - footpoint) + offset)
+    FeatureValue(lane.width/2 + norm(VecE2(curvept.pos - footpoint)) + offset)
 end
 generate_feature_functions("LaneOffsetLeft", :posFtL, Float64, "m", can_be_missing=true)
 function Base.get(::Feature_LaneOffsetLeft, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)

--- a/src/2d/features/lidar_sensors.jl
+++ b/src/2d/features/lidar_sensors.jl
@@ -293,7 +293,7 @@ function get_lane_portions(roadway::Roadway, x::Real, y::Real, lane_portion_max_
 
     for seg in roadway.segments
         for lane in seg.lanes
-            f = curvept -> abs2(curvept.pos - P) ≤ Δ²
+            f = curvept -> normsquared(VecE2(curvept.pos - P)) ≤ Δ²
             i = findfirst(f, lane.curve)
             if i != 0
                 j = findlast(f, lane.curve)

--- a/src/2d/roadway/curves.jl
+++ b/src/2d/roadway/curves.jl
@@ -70,9 +70,9 @@ function index_closest_to_point(curve::Curve, target::AbstractVec)
 
     @assert(length(curve) ≥ b)
 
-    sqdist_a = abs2(curve[a].pos - target)
-    sqdist_b = abs2(curve[b].pos - target)
-    sqdist_c = abs2(curve[c].pos - target)
+    sqdist_a = normsquared(VecE2(curve[a].pos - target))
+    sqdist_b = normsquared(VecE2(curve[b].pos - target))
+    sqdist_c = normsquared(VecE2(curve[c].pos - target))
 
     while true
         if b == a
@@ -90,10 +90,10 @@ function index_closest_to_point(curve::Curve, target::AbstractVec)
         end
 
         left = div(a+c, 2)
-        sqdist_l = abs2(curve[left].pos - target)
+        sqdist_l = normsquared(VecE2(curve[left].pos - target))
 
         right = div(c+b, 2)
-        sqdist_r = abs2(curve[right].pos - target)
+        sqdist_r = normsquared(VecE2(curve[right].pos - target))
 
         if sqdist_l < sqdist_r
             b = c
@@ -231,8 +231,8 @@ function Vec.proj(posG::VecSE2, curve::Curve)
         p_lo = lerp(curve[ind-1].pos, curve[ind].pos,   t_lo)
         p_hi = lerp(curve[ind].pos,   curve[ind+1].pos, t_hi)
 
-        d_lo = hypot(p_lo - posG)
-        d_hi = hypot(p_hi - posG)
+        d_lo = norm(VecE2(p_lo - posG))
+        d_hi = norm(VecE2(p_hi - posG))
 
         if d_lo < d_hi
             footpoint = p_lo

--- a/src/2d/roadway/roadway_generation.jl
+++ b/src/2d/roadway/roadway_generation.jl
@@ -8,7 +8,7 @@ export
 function gen_straight_curve(A::VecE2, B::VecE2, nsamples::Int)
 
     θ = atan2(B-A)
-    δ = abs(B-A)/(nsamples-1)
+    δ = norm(B-A)/(nsamples-1)
 
     s = 0.0
     curve = Array{CurvePt}(nsamples)
@@ -76,7 +76,7 @@ function gen_bezier_curve(A::VecSE2, B::VecSE2, rA::Float64, rB::Float64, nsampl
         κ = (P′.x*P′′.y - P′.y*P′′.x)/(P′.x^2 + P′.y^2)^1.5 # signed curvature
 
         if i > 1
-            s += abs(P - convert(VecE2, curve[i-1].pos)) # approximation, but should be good for many samples
+            s += norm(P - convert(VecE2, curve[i-1].pos)) # approximation, but should be good for many samples
         end
 
         curve[i] = CurvePt(VecSE2(P.x,P.y,θ), s, κ)

--- a/src/2d/roadway/roadways.jl
+++ b/src/2d/roadway/roadways.jl
@@ -249,7 +249,7 @@ function Base.getindex(lane::Lane, ind::CurveIndex, roadway::Roadway)
     if ind.i == 0
         pt_lo = prev_lane_point(lane, roadway)
         pt_hi = lane.curve[1]
-        s_gap = abs(pt_hi.pos - pt_lo.pos)
+        s_gap = norm(VecE2(pt_hi.pos - pt_lo.pos))
         pt_lo = CurvePt(pt_lo.pos, -s_gap, pt_lo.k, pt_lo.kd)
         lerp(pt_lo, pt_hi, ind.t)
     elseif ind.i < length(lane.curve)
@@ -257,7 +257,7 @@ function Base.getindex(lane::Lane, ind::CurveIndex, roadway::Roadway)
     else
         pt_hi = next_lane_point(lane, roadway)
         pt_lo = lane.curve[end]
-        s_gap = abs(pt_hi.pos - pt_lo.pos)
+        s_gap = norm(VecE2(pt_hi.pos - pt_lo.pos))
         pt_hi = CurvePt(pt_hi.pos, pt_lo.s + s_gap, pt_hi.k, pt_hi.kd)
         lerp( pt_lo, pt_hi, ind.t)
     end
@@ -424,7 +424,7 @@ function Vec.proj(posG::VecSE2, seg::RoadSegment, roadway::Roadway)
     for lane in seg.lanes
         roadproj = proj(posG, lane, roadway)
         footpoint = roadway[roadproj.tag][roadproj.curveproj.ind, roadway]
-        dist2 = abs2(posG - footpoint.pos)
+        dist2 = norm(VecE2(posG - footpoint.pos))
         if dist2 < best_dist2
             best_dist2 = dist2
             best_proj = roadproj
@@ -449,7 +449,7 @@ function Vec.proj(posG::VecSE2, roadway::Roadway)
             roadproj = proj(posG, lane, roadway, move_along_curves=false)
             targetlane = roadway[roadproj.tag]
             footpoint = targetlane[roadproj.curveproj.ind, roadway]
-            dist2 = abs2(posG - footpoint.pos)
+            dist2 = normsquared(VecE2(posG - footpoint.pos))
             if dist2 < best_dist2
                 best_dist2 = dist2
                 best_proj = roadproj
@@ -482,7 +482,7 @@ function move_along(roadind::RoadIndex, roadway::Roadway, Δs::Float64, depth::I
         if has_prev(lane)
             pt_lo = prev_lane_point(lane, roadway)
             pt_hi = lane.curve[1]
-            s_gap = abs(pt_hi.pos - pt_lo.pos)
+            s_gap = norm(VecE2(pt_hi.pos - pt_lo.pos))
 
             if curvept.s + Δs < -s_gap
                 lane_prev = prev_lane(lane, roadway)
@@ -503,7 +503,7 @@ function move_along(roadind::RoadIndex, roadway::Roadway, Δs::Float64, depth::I
         if has_next(lane)
             pt_lo = lane.curve[end]
             pt_hi = next_lane_point(lane, roadway)
-            s_gap = abs(pt_hi.pos - pt_lo.pos)
+            s_gap = norm(VecE2(pt_hi.pos - pt_lo.pos))
 
             if curvept.s + Δs ≥ pt_lo.s + s_gap # extends beyond the gap
                 curveind = lane.exits[1].target.ind
@@ -654,7 +654,7 @@ function read_dxf(io::IO, ::Type{Roadway};
         for (tag2, pts2) in lane_pts_dict
             if tag2.segment != tag.segment
                 for (ind,pt) in enumerate(pts2)
-                    sq_dist = abs2(pt - pts[end])
+                    sq_dist = normsquared(VecE2(pt - pts[end]))
                     if sq_dist < best_sq_dist
                         best_sq_dist = sq_dist
                         best_ind = ind
@@ -681,7 +681,7 @@ function read_dxf(io::IO, ::Type{Roadway};
             for (tag2, pts2) in lane_pts_dict
                 if tag2.segment != tag.segment
                     for (ind,pt) in enumerate(pts2)
-                        sq_dist = abs2(pt - pts[1])
+                        sq_dist = normsquared(VecE2(pt - pts[1]))
                         if sq_dist < best_sq_dist
                             best_sq_dist = sq_dist
                             best_ind = ind
@@ -815,4 +815,3 @@ function read_dxf(io::IO, ::Type{Roadway};
 
     retval
 end
-

--- a/src/2d/utils/minkowski.jl
+++ b/src/2d/utils/minkowski.jl
@@ -142,7 +142,7 @@ function ensure_pts_sorted_by_min_polar_angle!(poly::ConvexPolygon, npts::Int=po
     angle_start = Inf
     index_start = -1
     for i in 1 : npts
-        seg = get_edge(poly.pts, i)
+        seg = get_edge(poly.pts, i, npts)
 
         θ = atan2(seg.B.y - seg.A.y, seg.B.x - seg.A.x)
         if θ < 0.0
@@ -335,7 +335,7 @@ function get_time_and_dist_of_closest_approach(a::Vehicle, b::Vehicle, mem::CPAM
 
     rel_pos = convert(VecE2, b.state.posG) - a.state.posG
     rel_velocity = polar(b.state.v, b.state.posG.θ) - polar(a.state.v, a.state.posG.θ)
-    ray_speed = hypot(rel_velocity)
+    ray_speed = norm(VecE2(rel_velocity))
     ray = VecSE2(rel_pos, atan2(rel_velocity))
 
     if contains(mem.mink, convert(VecE2, ray))
@@ -367,7 +367,7 @@ _bounding_radius(veh::Vehicle) = sqrt(veh.def.length*veh.def.length/4 + veh.def.
 A fast collision check to remove things clearly not colliding
 """
 function is_potentially_colliding(A::Vehicle, B::Vehicle)
-    Δ² = abs2(A.state.posG - B.state.posG)
+    Δ² = normsquared(VecE2(A.state.posG - B.state.posG))
     r_a = _bounding_radius(A)
     r_b = _bounding_radius(B)
     Δ² ≤ r_a*r_a + 2*r_a*r_b + r_b*r_b

--- a/src/2d/vehicles/scenes.jl
+++ b/src/2d/vehicles/scenes.jl
@@ -66,13 +66,13 @@ function get_neighbor_fore_along_lane{S<:VehicleState,D<:Union{VehicleDef, Bicyc
                 elseif is_between_segments_hi(veh.state.posF.roadind.ind, lane.curve) &&
                        is_in_entrances(roadway[tag_target], veh.state.posF.roadind.tag)
 
-                    distance_between_lanes = abs(roadway[tag_target].curve[1].pos - roadway[veh.state.posF.roadind.tag].curve[end].pos)
+                    distance_between_lanes = norm(VecE2(roadway[tag_target].curve[1].pos - roadway[veh.state.posF.roadind.tag].curve[end].pos))
                     s_adjust = -(roadway[veh.state.posF.roadind.tag].curve[end].s + distance_between_lanes)
 
                 elseif is_between_segments_lo(veh.state.posF.roadind.ind) &&
                        is_in_exits(roadway[tag_target], veh.state.posF.roadind.tag)
 
-                    distance_between_lanes = abs(roadway[tag_target].curve[end].pos - roadway[veh.state.posF.roadind.tag].curve[1].pos)
+                    distance_between_lanes = norm(VecE2(roadway[tag_target].curve[end].pos - roadway[veh.state.posF.roadind.tag].curve[1].pos))
                     s_adjust = roadway[tag_target].curve[end].s + distance_between_lanes
                 end
 
@@ -101,7 +101,7 @@ function get_neighbor_fore_along_lane{S<:VehicleState,D<:Union{VehicleDef, Bicyc
         end
 
         dist_searched += (lane.curve[end].s - s_base)
-        s_base = -abs(lane.curve[end].pos - next_lane_point(lane, roadway).pos) # negative distance between lanes
+        s_base = -norm(VecE2(lane.curve[end].pos - next_lane_point(lane, roadway).pos)) # negative distance between lanes
         tag_target = next_lane(lane, roadway).tag
     end
 
@@ -254,13 +254,13 @@ function get_neighbor_rear_along_lane{S<:VehicleState,D<:Union{VehicleDef, Bicyc
                 elseif is_between_segments_hi(veh.state.posF.roadind.ind, lane.curve) &&
                        is_in_entrances(roadway[tag_target], veh.state.posF.roadind.tag)
 
-                    distance_between_lanes = abs(roadway[tag_target].curve[1].pos - roadway[veh.state.posF.roadind.tag].curve[end].pos)
+                    distance_between_lanes = norm(VecE2(roadway[tag_target].curve[1].pos - roadway[veh.state.posF.roadind.tag].curve[end].pos))
                     s_adjust = -(roadway[veh.state.posF.roadind.tag].curve[end].s + distance_between_lanes)
 
                 elseif is_between_segments_lo(veh.state.posF.roadind.ind) &&
                        is_in_exits(roadway[tag_target], veh.state.posF.roadind.tag)
 
-                    distance_between_lanes = abs(roadway[tag_target].curve[end].pos - roadway[veh.state.posF.roadind.tag].curve[1].pos)
+                    distance_between_lanes = norm(VecE2(roadway[tag_target].curve[end].pos - roadway[veh.state.posF.roadind.tag].curve[1].pos))
                     s_adjust = roadway[tag_target].curve[end].s + distance_between_lanes
                 end
 
@@ -291,7 +291,7 @@ function get_neighbor_rear_along_lane{S<:VehicleState,D<:Union{VehicleDef, Bicyc
         end
 
         dist_searched += s_base
-        s_base = lane.curve[end].s + abs(lane.curve[end].pos - prev_lane_point(lane, roadway).pos) # end of prev lane plus crossover
+        s_base = lane.curve[end].s + norm(VecE2(lane.curve[end].pos - prev_lane_point(lane, roadway).pos)) # end of prev lane plus crossover
         tag_target = prev_lane(lane, roadway).tag
     end
 
@@ -442,20 +442,20 @@ function get_frenet_relative_position(posG::VecSE2, roadind::RoadIndex, roadway:
     s_base = lane_start[roadind.ind, roadway].s
     s_proj = curvept_start.s
     Δs = s_proj - s_base
-    sq_dist_to_curve = abs2(posG - curvept_start.pos)
+    sq_dist_to_curve = normsquared(VecE2(posG - curvept_start.pos))
     retval = FrenetRelativePosition(roadind,
                 RoadIndex(curveproj_start.ind, tag_start), Δs, curveproj_start.t, curveproj_start.ϕ)
 
     # search downstream
     if has_next(lane_start)
         dist_searched = lane_start.curve[end].s - s_base
-        s_base = -abs(lane_start.curve[end].pos - next_lane_point(lane_start, roadway).pos) # negative distance between lanes
+        s_base = -norm(VecE2(lane_start.curve[end].pos - next_lane_point(lane_start, roadway).pos)) # negative distance between lanes
         tag_target = next_lane(lane_start, roadway).tag
         while dist_searched < max_distance_fore
 
             lane = roadway[tag_target]
             curveproj = proj(posG, lane, roadway, move_along_curves=false).curveproj
-            sq_dist_to_curve2 = abs2(posG - lane[curveproj.ind, roadway].pos)
+            sq_dist_to_curve2 = normsquared(VecE2(posG - lane[curveproj.ind, roadway].pos))
 
             if sq_dist_to_curve2 < sq_dist_to_curve - improvement_threshold
 
@@ -472,7 +472,7 @@ function get_frenet_relative_position(posG::VecSE2, roadind::RoadIndex, roadway:
             end
 
             dist_searched += (lane.curve[end].s - s_base)
-            s_base = -abs(lane.curve[end].pos - next_lane_point(lane, roadway).pos) # negative distance between lanes
+            s_base = -norm(VecE2(lane.curve[end].pos - next_lane_point(lane, roadway).pos)) # negative distance between lanes
             tag_target = next_lane(lane, roadway).tag
 
             if tag_target == tag_start
@@ -485,13 +485,13 @@ function get_frenet_relative_position(posG::VecSE2, roadind::RoadIndex, roadway:
     if has_prev(lane_start)
         dist_searched = s_base
         tag_target = prev_lane(lane_start, roadway).tag
-        s_base = roadway[tag_target].curve[end].s + abs(lane_start.curve[1].pos - prev_lane_point(lane_start, roadway).pos) # end of the lane
+        s_base = roadway[tag_target].curve[end].s + norm(VecE2(lane_start.curve[1].pos - prev_lane_point(lane_start, roadway).pos)) # end of the lane
 
         while dist_searched < max_distance_fore
 
             lane = roadway[tag_target]
             curveproj = proj(posG, lane, roadway, move_along_curves=false).curveproj
-            sq_dist_to_curve2 = abs2(posG - lane[curveproj.ind, roadway].pos)
+            sq_dist_to_curve2 = normsquared(VecE2(posG - lane[curveproj.ind, roadway].pos))
 
             if sq_dist_to_curve2 < sq_dist_to_curve - improvement_threshold
 
@@ -509,7 +509,7 @@ function get_frenet_relative_position(posG::VecSE2, roadind::RoadIndex, roadway:
             end
 
             dist_searched += s_base
-            s_base = lane.curve[end].s + abs(lane.curve[1].pos - prev_lane_point(lane, roadway).pos) # length of this lane plus crossover
+            s_base = lane.curve[end].s + norm(VecE2(lane.curve[1].pos - prev_lane_point(lane, roadway).pos)) # length of this lane plus crossover
             tag_target = prev_lane(lane, roadway).tag
 
             if tag_target == tag_start

--- a/test/2d/roadway/test_roadways.jl
+++ b/test/2d/roadway/test_roadways.jl
@@ -463,7 +463,7 @@ let
                 @test isapprox(conn1.target.ind.t, conn2.target.ind.t, atol=1e-3)
             end
             for (pt1, pt2) in zip(lane1.curve, lane2.curve)
-                @test abs2(convert(VecE2, pt1.pos) - convert(VecE2, pt2.pos)) < 0.01
+                @test normsquared(convert(VecE2, pt1.pos) - convert(VecE2, pt2.pos)) < 0.01
                 @test angledist(pt1.pos.θ, pt2.pos.θ) < 1e-5
                 @test isnan(pt1.s) || isapprox(pt1.s, pt2.s, atol=1e-3)
                 @test isnan(pt1.k) || isapprox(pt1.k, pt2.k, atol=1e-6)


### PR DESCRIPTION
The package can work with the new version of Vec.jl using StaticArrays. 
Changes were mostly replacing `abs` or `abs2` by `norm` or `normsquared`. 

I think I spotted one bug on the minkowski sum function in `utils/minkowski.jl` l145:
```julia 
seg = get_edge(poly.pts, i)
```
instead of 
```julia
seg = get_edge(poly.pts, i, npts)
```
which prevent from accessing undefined reference in the poly.npts. 

In the future, the ConvexPolygon type should probably be immutable.
