### PR TITLE
linspace -> range

### DIFF
--- a/src/2d/features/lidar_sensors.jl
+++ b/src/2d/features/lidar_sensors.jl
@@ -26,7 +26,7 @@ function LidarSensor(nbeams::Int;
     )
 
     if nbeams > 1
-        angles = collect(linspace(angle_offset-angle_spread/2,angle_offset + angle_spread/2,nbeams+1))[2:end]
+        angles = collect(range(angle_offset-angle_spread/2,angle_offset + angle_spread/2,nbeams+1))[2:end]
     else
         angles = Float64[]
         nbeams = 0
@@ -99,7 +99,7 @@ function RoadlineLidarSensor(nbeams::Int;
     )
 
     if nbeams > 1
-        angles = collect(linspace(angle_offset,2*pi+angle_offset,nbeams+1))[2:end]
+        angles = collect(range(angle_offset,2*pi+angle_offset,nbeams+1))[2:end]
     else
         angles = Float64[]
         nbeams = 0

--- a/src/2d/features/lidar_sensors.jl
+++ b/src/2d/features/lidar_sensors.jl
@@ -26,7 +26,7 @@ function LidarSensor(nbeams::Int;
     )
 
     if nbeams > 1
-        angles = collect(range(angle_offset-angle_spread/2,angle_offset + angle_spread/2,nbeams+1))[2:end]
+        angles = collect(LinRange(angle_offset-angle_spread/2,angle_offset + angle_spread/2,nbeams+1))[2:end]
     else
         angles = Float64[]
         nbeams = 0
@@ -99,7 +99,7 @@ function RoadlineLidarSensor(nbeams::Int;
     )
 
     if nbeams > 1
-        angles = collect(range(angle_offset,2*pi+angle_offset,nbeams+1))[2:end]
+        angles = collect(LinRange(angle_offset,2*pi+angle_offset,nbeams+1))[2:end]
     else
         angles = Float64[]
         nbeams = 0


### PR DESCRIPTION
Removes deprecated linspace in favor of range. 

See example here: https://github.com/JuliaPy/PyCall.jl/issues/518