### PR TITLE
IDM pdf infinity bugfix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutomotiveDrivingModels"
 uuid = "99497e54-f3d6-53d3-a3a9-fa9315a7f1ba"
 repo = "https://github.com/sisl/AutomotiveDrivingModels.jl.git"
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/behaviors/intelligent_driver_model.jl
+++ b/src/behaviors/intelligent_driver_model.jl
@@ -78,14 +78,14 @@ function Base.rand(model::IntelligentDriverModel)
 end
 function Distributions.pdf(model::IntelligentDriverModel, a::LaneFollowingAccel)
     if isnan(model.σ) || model.σ ≤ 0.0
-        Inf
+        a == model.a ? Inf : 0.
     else
         pdf(Normal(model.a, model.σ), a.a)
     end
 end
 function Distributions.logpdf(model::IntelligentDriverModel, a::LaneFollowingAccel)
     if isnan(model.σ) || model.σ ≤ 0.0
-        Inf
+        a == model.a ? Inf : 0.
     else
         logpdf(Normal(model.a, model.σ), a.a)
     end

--- a/src/behaviors/intelligent_driver_model.jl
+++ b/src/behaviors/intelligent_driver_model.jl
@@ -71,22 +71,22 @@ reset_hidden_state!(model::IntelligentDriverModel) = model
 
 function Base.rand(model::IntelligentDriverModel)
     if isnan(model.σ) || model.σ ≤ 0.0
-        LaneFollowingAccel(model.a)
+        return LaneFollowingAccel(model.a)
     else
-        LaneFollowingAccel(rand(Normal(model.a, model.σ)))
+        return LaneFollowingAccel(rand(Normal(model.a, model.σ)))
     end
 end
 function Distributions.pdf(model::IntelligentDriverModel, a::LaneFollowingAccel)
     if isnan(model.σ) || model.σ ≤ 0.0
-        a == model.a ? Inf : 0.
+        return a == model.a ? Inf : 0.
     else
-        pdf(Normal(model.a, model.σ), a.a)
+        return pdf(Normal(model.a, model.σ), a.a)
     end
 end
 function Distributions.logpdf(model::IntelligentDriverModel, a::LaneFollowingAccel)
     if isnan(model.σ) || model.σ ≤ 0.0
-        a == model.a ? Inf : 0.
+        return a == model.a ? Inf : 0.
     else
-        logpdf(Normal(model.a, model.σ), a.a)
+        return logpdf(Normal(model.a, model.σ), a.a)
     end
 end


### PR DESCRIPTION
The `pdf()` of an IDM was returning `Inf` regardless of the action `a`