### PR TITLE
Introduce a state interface: `posf`, `posg`, `vel` ...

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,17 +4,17 @@ This is the documentation for AutomotiveDrivingModels.jl.
 
 ## Concepts
 
-This section defines a few term that are used accross the package. 
+This section defines a few terms that are used across the package. 
 See the specific section of the documentation for a more thorough explanation.
 
-- **Entity**: An entity is a traffic participants that navigates in the environment, it is defined by a physical state (position, velocity, ...), an agent definition (whether it is a car or pedestrian, how large it is, ...), and an ID.
+- **Entity**: An entity is a traffic participant that navigates in the environment, it is defined by a physical state (position, velocity, ...), an agent definition (whether it is a car or pedestrian, how large it is, ...), and an ID.
 - **Scene**: A scene represents a snapshot in time of a driving situation, it essentially consists of a list of entities at a given time.
-- **Driver Model**: A driver model is a distribution over action. Given a scene, each entity can updates its model, we call this process observation (the corresponding method is `observe!`). After observing the scene, an action can be sampled from the driver model (using `rand`).
+- **Driver Model**: A driver model is a distribution over actions. Given a scene, each entity can update its model, we call this process observation (the corresponding method is `observe!`). After observing the scene, an action can be sampled from the driver model (using `rand`).
 - **Actions**: An action consists of a command applied to move the entity (e.g. longitudinal acceleration, steering). The state of the entity is updated using the `propagate` method which encodes the dynamics model.
 
-This package provides default structure for representing entity states, entities, scenes, driver model and actions.
-However it has been design to support custom types. 
-Each section of the documentation contains an interface, which is a list of function that a user must implement to use its own types.
+This package provides a default structure for representing entity states, entities, scenes, driver models and actions.
+However it has been designed to support custom types. 
+Each section of the documentation contains an interface, which is a list of functions that a user must implement to use its own types.
 
 ```@contents
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,20 @@
 # About
 
-This is the documentation for AutomotiveDrivingModels.jl. Placeholder for now
+This is the documentation for AutomotiveDrivingModels.jl. 
+
+## Concepts
+
+This section defines a few term that are used accross the package. 
+See the specific section of the documentation for a more thorough explanation.
+
+- **Entity**: An entity is a traffic participants that navigates in the environment, it is defined by a physical state (position, velocity, ...), an agent definition (whether it is a car or pedestrian, how large it is, ...), and an ID.
+- **Scene**: A scene represents a snapshot in time of a driving situation, it essentially consists of a list of entities at a given time.
+- **Driver Model**: A driver model is a distribution over action. Given a scene, each entity can updates its model, we call this process observation (the corresponding method is `observe!`). After observing the scene, an action can be sampled from the driver model (using `rand`).
+- **Actions**: An action consists of a command applied to move the entity (e.g. longitudinal acceleration, steering). The state of the entity is updated using the `propagate` method which encodes the dynamics model.
+
+This package provides default structure for representing entity states, entities, scenes, driver model and actions.
+However it has been design to support custom types. 
+Each section of the documentation contains an interface, which is a list of function that a user must implement to use its own types.
 
 ```@contents
 ```

--- a/docs/src/states.md
+++ b/docs/src/states.md
@@ -4,14 +4,45 @@ In this section of the documentation we explain the default vehicle state type p
 as well as the data types used to represent driving scene. Most of the underlying structures are defined in `Records.jl`. 
 The data structure provided in ADM.jl are concrete instances of parametric types defined in Records. It is possible in principle to define your custom state definition and use the interface defined in ADM.jl.
 
-## Agent States
+## Entity state
 
-Agents are represented by  the entity data type provided by `Records.jl`.
+Entities are represented by  the entity data type provided by `Records.jl`.
 The entity data type has three field: a state, a definition, and an id. 
 
 The state of an entity usually describes physical quantity such as position and velocity. 
 
 Two states data structure are provided.
+
+## Defining your own state type
+
+You can define your own state type if the provided `VehicleState` does not contain the right information.
+There are a couple functions that needs to be defined such that other functions in AutomotiveDrivingModels can work smoothly with your custom state type.
+
+```@docs
+    posg()
+    posf
+    vel
+    velf
+    velg
+```
+
+**Example of a custom state type containing acceleration:**
+
+```julia
+
+# you can use composition to define your state type
+struct MyVehicleState
+    veh::VehicleState
+    acc::Float64
+end
+
+# define the function from the interface 
+posg(s::MyVehicleState) = posg(s.veh) # those functions are implemented for the `VehicleState` type
+posf(s::MyVehicleState) = posf(s.veh)
+velg(s::MyVehicleState) = velg(s.veh)
+velf(s::MyVehicleState) = velf(s.veh)
+vel(s::MyVehicleState) = vel(s.veh)
+```
 
 ### 1D states and vehicles
 
@@ -27,8 +58,6 @@ Here we list useful functions to interact with vehicle states and retrieve inter
 ```@docs 
     VehicleState
     Vec.lerp(a::VehicleState, b::VehicleState, t::Float64, roadway::Roadway)
-    get_vel_s
-    get_vel_t
     move_along(vehstate::VehicleState, roadway::Roadway, Δs::Float64; ϕ₂::Float64=vehstate.posF.ϕ, ::Float64=vehstate.posF.t, v₂::Float64=vehstate.v)
     Vehicle
     get_front

--- a/docs/src/states.md
+++ b/docs/src/states.md
@@ -6,7 +6,7 @@ The data structures provided in ADM.jl are concrete instances of parametric type
 
 ## Entity state
 
-Entities are represented by the `Entity` data type provided by `Records.jl`.
+Entities are represented by the `Entity` data type provided by `Records.jl` (https://github.com/sisl/Records.jl/blob/master/src/entities.jl).
 The `Entity` data type has three fields: a state, a definition and an id. 
 
 The state of an entity usually describes physical quantity such as position and velocity. 

--- a/docs/src/states.md
+++ b/docs/src/states.md
@@ -1,25 +1,25 @@
 # States 
 
 In this section of the documentation we explain the default vehicle state type provided by `AutomotiveDrivingModels`
-as well as the data types used to represent driving scene. Most of the underlying structures are defined in `Records.jl`. 
-The data structure provided in ADM.jl are concrete instances of parametric types defined in Records. It is possible in principle to define your custom state definition and use the interface defined in ADM.jl.
+as well as the data types used to represent a driving scene. Most of the underlying structures are defined in `Records.jl`. 
+The data structures provided in ADM.jl are concrete instances of parametric types defined in Records. It is possible in principle to define your custom state definition and use the interface defined in ADM.jl.
 
 ## Entity state
 
-Entities are represented by  the entity data type provided by `Records.jl`.
-The entity data type has three field: a state, a definition, and an id. 
+Entities are represented by the `Entity` data type provided by `Records.jl`.
+The `Entity` data type has three fields: a state, a definition and an id. 
 
 The state of an entity usually describes physical quantity such as position and velocity. 
 
-Two states data structure are provided.
+Two state data structures are provided.
 
 ## Defining your own state type
 
 You can define your own state type if the provided `VehicleState` does not contain the right information.
-There are a couple functions that needs to be defined such that other functions in AutomotiveDrivingModels can work smoothly with your custom state type.
+There are a of couple functions that need to be defined such that other functions in AutomotiveDrivingModels can work smoothly with your custom state type.
 
 ```@docs
-    posg()
+    posg
     posf
     vel
     velf
@@ -30,13 +30,13 @@ There are a couple functions that needs to be defined such that other functions 
 
 ```julia
 
-# you can use composition to define your state type
+# you can use composition to define your custom state type based on existing ones
 struct MyVehicleState
     veh::VehicleState
     acc::Float64
 end
 
-# define the function from the interface 
+# define the functions from the interface 
 posg(s::MyVehicleState) = posg(s.veh) # those functions are implemented for the `VehicleState` type
 posf(s::MyVehicleState) = posf(s.veh)
 velg(s::MyVehicleState) = velg(s.veh)
@@ -53,7 +53,7 @@ vel(s::MyVehicleState) = vel(s.veh)
 
 ### 2D states and vehicles
 
-Here we list useful functions to interact with vehicle states and retrieve interesting information like the position of the front of the vehicle or the lane to which the vehicle belong.
+Here we list useful functions to interact with vehicle states and retrieve interesting information like the position of the front of the vehicle or the lane to which the vehicle belongs.
 
 ```@docs 
     VehicleState

--- a/src/AutomotiveDrivingModels.jl
+++ b/src/AutomotiveDrivingModels.jl
@@ -74,7 +74,6 @@ include("roadways/roadways.jl")
 
 export 
     Frenet,
-    get_posG,
     NULL_FRENET
 
 include("roadways/frenet.jl")
@@ -112,6 +111,11 @@ export
 include("states/1d_states.jl")
 
 export
+    posf,
+    posg,
+    vel,
+    velf,
+    velg,
     VehicleState,
     Vehicle,
     get_vel_s,
@@ -122,6 +126,7 @@ export
     get_rear,
     get_lane
 
+include("states/interface.jl")
 include("states/vehicle_state.jl")
 
 export
@@ -294,5 +299,7 @@ export
 
 include("simulation/simulation.jl")
 include("simulation/callbacks.jl")
+
+include("deprecated.jl")
 
 end # AutomotiveDrivingModels

--- a/src/actions/accel_desang.jl
+++ b/src/actions/accel_desang.jl
@@ -40,10 +40,8 @@ function propagate(veh::Entity{VehicleState,D,I}, action::AccelDesang, roadway::
     a = action.a # accel
     ϕdes = action.ϕdes # desired heading angle
 
-    x = veh.state.posG.x
-    y = veh.state.posG.y
-    θ = veh.state.posG.θ
-    v = veh.state.v
+    x, y, θ = posg(veh.state)
+    v = vel(veh.state)
 
     δt = Δt/n_integration_steps
 

--- a/src/actions/accel_steering.jl
+++ b/src/actions/accel_steering.jl
@@ -43,16 +43,14 @@ function propagate(veh::Entity{VehicleState, BicycleModel, Int}, action::AccelSt
     a = action.a # accel [m/s²]
     δ = action.δ # steering wheel angle [rad]
 
-    x = veh.state.posG.x
-    y = veh.state.posG.y
-    θ = veh.state.posG.θ
-    v = veh.state.v
+    x, y, θ = posg(veh.state)
+    v = vel(veh.state)
 
     s = v*Δt + a*Δt*Δt/2 # distance covered
     v′ = v + a*Δt
 
     if abs(δ) < 0.01 # just drive straight
-        posG = veh.state.posG + polar(s, θ)
+        posG = posg(veh.state) + polar(s, θ)
     else # drive in circle
 
         R = L/tan(δ) # turn radius

--- a/src/actions/accel_turnrate.jl
+++ b/src/actions/accel_turnrate.jl
@@ -37,10 +37,8 @@ function propagate(veh::Entity{VehicleState,D,I}, action::AccelTurnrate, roadway
     a = action.a # accel
     ω = action.ω # turnrate
 
-    x = veh.state.posG.x
-    y = veh.state.posG.y
-    θ = veh.state.posG.θ
-    v = veh.state.v
+    x, y, θ = posg(veh.state)
+    v = vel(veh.state)
 
     δt = Δt / n_integration_steps
 

--- a/src/actions/lane_following_accel.jl
+++ b/src/actions/lane_following_accel.jl
@@ -26,26 +26,15 @@ function propagate(veh::Entity{VehicleState,D,I}, action::LaneFollowingAccel, ro
 
     a_lon = action.a
 
-    ds = veh.state.v
+    ds = vel(veh.state)
 
     ΔT² = ΔT*ΔT
     Δs = ds*ΔT + 0.5*a_lon*ΔT²
 
     v₂ = ds + a_lon*ΔT
 
-    roadind = move_along(veh.state.posF.roadind, roadway, Δs)
+    roadind = move_along(posf(veh.state).roadind, roadway, Δs)
     posG = roadway[roadind].pos
-    posF = Frenet(roadind, roadway, t=veh.state.posF.t, ϕ=veh.state.posF.ϕ)
+    posF = Frenet(roadind, roadway, t=posf(veh.state).t, ϕ=posf(veh.state).ϕ)
     VehicleState(posG, posF, v₂)
 end
-
-
-#XXX these should probably be removed
-# Base.show(io::IO, a::LaneFollowingAccel) = @printf(io, "LaneFollowingAccel(%6.3f)", a.a)
-# Base.length(::Type{LaneFollowingAccel}) = 1
-# Base.convert(::Type{LaneFollowingAccel}, v::Vector{Float64}) = LaneFollowingAccel(v[1])
-
-# function Base.copyto!(v::Vector{Float64}, a::LaneFollowingAccel)
-#     v[1] = a.a
-#     v
-# end

--- a/src/actions/lat_lon_accel.jl
+++ b/src/actions/lat_lon_accel.jl
@@ -23,10 +23,10 @@ function propagate(veh::Entity{VehicleState, D, I}, action::LatLonAccel, roadway
     a_lat = action.a_lat
     a_lon = action.a_lon
 
-     v = veh.state.v
-     ϕ = veh.state.posF.ϕ
+     v = vel(veh.state)
+     ϕ = posf(veh.state).ϕ
     ds = v*cos(ϕ)
-     t = veh.state.posF.t
+     t = posf(veh.state).t
     dt = v*sin(ϕ)
 
     ΔT² = ΔT*ΔT
@@ -39,7 +39,7 @@ function propagate(veh::Entity{VehicleState, D, I}, action::LatLonAccel, roadway
     v₂ = sqrt(dt₂*dt₂ + ds₂*ds₂) # v is the magnitude of the velocity vector
     ϕ₂ = atan(dt₂, ds₂)
 
-    roadind = move_along(veh.state.posF.roadind, roadway, Δs)
+    roadind = move_along(posf(veh.state).roadind, roadway, Δs)
     footpoint = roadway[roadind]
     posG = VecE2{Float64}(footpoint.pos.x,footpoint.pos.y) + polar(t + Δt, footpoint.pos.θ + π/2)
 

--- a/src/actions/pedestrian_lat_lon_accel.jl
+++ b/src/actions/pedestrian_lat_lon_accel.jl
@@ -20,7 +20,7 @@ function AutomotiveDrivingModels.propagate(ped::Entity{VehicleState, D, I},
                                            ΔT::Float64=0.1
                                            ) where {D,I}
     state = propagate(ped, LatLonAccel(action.a_lat, action.a_lon), roadway, ΔT)
-    roadproj = proj(state.posG, roadway[action.lane_des.tag], roadway, move_along_curves=false)
-    retval = VehicleState(Frenet(roadproj, roadway), roadway, state.v)
+    roadproj = proj(posg(state), roadway[action.lane_des.tag], roadway, move_along_curves=false)
+    retval = VehicleState(Frenet(roadproj, roadway), roadway, vel(state))
     return retval
 end

--- a/src/behaviors/MOBIL.jl
+++ b/src/behaviors/MOBIL.jl
@@ -52,7 +52,7 @@ function observe!(model::MOBIL, scene::Frame{Entity{S, D, I}}, roadway::Roadway,
 
     vehicle_index = findfirst(egoid, rec[0])
     veh_ego = scene[vehicle_index]
-    v = veh_ego.state.v
+    v = vel(veh_ego.state)
     egostate_M = veh_ego.state
 
     left_lane_exists = convert(Float64, get(N_LANE_LEFT, rec, roadway, vehicle_index)) > 0
@@ -72,11 +72,11 @@ function observe!(model::MOBIL, scene::Frame{Entity{S, D, I}}, roadway::Roadway,
 
         # candidate position after lane change is over
         footpoint = get_footpoint(veh_ego)
-        lane = roadway[veh_ego.state.posF.roadind.tag]
+        lane = get_lane(roadway, veh_ego) 
         lane_L = roadway[LaneTag(lane.tag.segment, lane.tag.lane + 1)]
         roadproj = proj(footpoint, lane_L, roadway)
         frenet_L = Frenet(RoadIndex(roadproj), roadway)
-        egostate_L = VehicleState(frenet_L, roadway, veh_ego.state.v)
+        egostate_L = VehicleState(frenet_L, roadway, vel(veh_ego.state))
 
         Δaccel_n = 0.0
         passes_safety_criterion = true
@@ -140,7 +140,7 @@ function observe!(model::MOBIL, scene::Frame{Entity{S, D, I}}, roadway::Roadway,
         lane_R = roadway[LaneTag(lane.tag.segment, lane.tag.lane - 1)]
         roadproj = proj(footpoint, lane_R, roadway)
         frenet_R = Frenet(RoadIndex(roadproj), roadway)
-        egostate_R = VehicleState(frenet_R, roadway, veh_ego.state.v)
+        egostate_R = VehicleState(frenet_R, roadway, vel(veh_ego.state))
 
         Δaccel_n = 0.0
         passes_safety_criterion = true

--- a/src/behaviors/lane_change_models.jl
+++ b/src/behaviors/lane_change_models.jl
@@ -12,7 +12,7 @@ Base.show(io::IO, a::LaneChangeChoice) = @printf(io, "LaneChangeChoice(%d)", a.d
 
 function get_lane_offset(a::LaneChangeChoice, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     if a.dir == DIR_MIDDLE
-        rec[pastframe][vehicle_index].state.posF.t
+        posf(rec[pastframe][vehicle_index].state).t
     elseif a.dir == DIR_LEFT
         convert(Float64, get(LANEOFFSETLEFT, rec, roadway, vehicle_index, pastframe))
     else

--- a/src/behaviors/lane_following_drivers.jl
+++ b/src/behaviors/lane_following_drivers.jl
@@ -7,8 +7,8 @@ function observe!(model::LaneFollowingDriver, scene::Frame{Entity{State1D, D, I}
 
     fore_res = get_neighbor_fore(scene, vehicle_index, roadway)
 
-    v_ego = scene[vehicle_index].state.v
-    v_oth = scene[fore_res.ind].state.v
+    v_ego = vel(scene[vehicle_index].state)
+    v_oth = vel(scene[fore_res.ind].state)
     headway = fore_res.Δs
 
     track_longitudinal!(model, v_ego, v_oth, headway)

--- a/src/behaviors/lat_lon_separable_driver.jl
+++ b/src/behaviors/lat_lon_separable_driver.jl
@@ -10,12 +10,12 @@ function observe!(model::LaneFollowingDriver, scene::Frame{Entity{S, D, I}}, roa
 
     fore = get_neighbor_fore_along_lane(scene, vehicle_index, roadway, VehicleTargetPointFront(), VehicleTargetPointRear(), VehicleTargetPointFront())
 
-    v_ego = scene[vehicle_index].state.v
+    v_ego = vel(scene[vehicle_index].state)
     v_oth = NaN
     headway = NaN
 
     if fore.ind != nothing
-        v_oth = scene[fore.ind].state.v
+        v_oth = vel(scene[fore.ind].state)
         headway = fore.Δs
     end
 

--- a/src/behaviors/lateral_driver_models.jl
+++ b/src/behaviors/lateral_driver_models.jl
@@ -15,37 +15,26 @@ A controller that executes the lane change decision made by the `lane change mod
 - `kp::Float64 = 3.0` proportional constant for lane tracking
 - `kd::Float64 = 2.0` derivative constant for lane tracking
 """
-mutable struct ProportionalLaneTracker <: LateralDriverModel{Float64}
-    a::Float64 # predicted acceleration
-    σ::Float64 # optional stdev on top of the model, set to zero or NaN for deterministic behavior
-    kp::Float64 # proportional constant for lane tracking
-    kd::Float64 # derivative constant for lane tracking
-
-    function ProportionalLaneTracker(;
-        σ::Float64 = NaN,
-        kp::Float64 = 3.0,
-        kd::Float64 = 2.0,
-        )
-
-        retval = new()
-        retval.a = NaN
-        retval.σ = σ
-        retval.kp = kp
-        retval.kd = kd
-        retval
-    end
+@with_kw mutable struct ProportionalLaneTracker <: LateralDriverModel{Float64}
+    a::Float64 = NaN # predicted acceleration
+    σ::Float64 = NaN # optional stdev on top of the model, set to zero or NaN for deterministic behavior
+    kp::Float64 = 3.0 # proportional constant for lane tracking
+    kd::Float64 = 2.0 # derivative constant for lane tracking
 end
+
 get_name(::ProportionalLaneTracker) = "ProportionalLaneTracker"
+
 function track_lateral!(model::ProportionalLaneTracker, laneoffset::Float64, lateral_speed::Float64)
     model.a = -laneoffset*model.kp - lateral_speed*model.kd
     model
 end
+
 function observe!(model::ProportionalLaneTracker, scene::Frame{Entity{S, D, I}}, roadway::Roadway, egoid::I) where {S, D, I}
 
     ego_index = findfirst(egoid, scene)
     veh_ego = scene[ego_index]
-    t = veh_ego.state.posF.t # lane offset
-    dt = veh_ego.state.v * sin(veh_ego.state.posF.ϕ) # rate of change of lane offset
+    t = posf(veh_ego.state).t # lane offset
+    dt = velf(veh_ego.state).t # rate of change of lane offset
     model.a = -t*model.kp - dt*model.kd
 
     model

--- a/src/behaviors/tim_2d_driver.jl
+++ b/src/behaviors/tim_2d_driver.jl
@@ -16,25 +16,17 @@ mutable struct Tim2DDriver <: DriverModel{LatLonAccel}
     mlon::LaneFollowingDriver
     mlat::LateralDriverModel
     mlane::LaneChangeModel
-
-    function Tim2DDriver(
+end
+function Tim2DDriver(
         timestep::Float64;
         mlon::LaneFollowingDriver=IntelligentDriverModel(),
         mlat::LateralDriverModel=ProportionalLaneTracker(),
         mlane::LaneChangeModel=TimLaneChanger(timestep),
         rec::SceneRecord = SceneRecord(1, timestep)
         )
-
-        retval = new()
-
-        retval.rec = rec
-        retval.mlon = mlon
-        retval.mlat = mlat
-        retval.mlane = mlane
-
-        retval
-    end
+    return Tim2DDriver(rec, mlon, mlat, mlane)
 end
+
 get_name(::Tim2DDriver) = "Tim2DDriver"
 function set_desired_speed!(model::Tim2DDriver, v_des::Float64)
     set_desired_speed!(model.mlon, v_des)
@@ -42,9 +34,9 @@ function set_desired_speed!(model::Tim2DDriver, v_des::Float64)
     model
 end
 function track_longitudinal!(driver::LaneFollowingDriver, scene::Frame{Entity{VehicleState, D, I}}, roadway::Roadway, vehicle_index::I, fore::NeighborLongitudinalResult) where {D, I}
-    v_ego = scene[vehicle_index].state.v
+    v_ego = vel(scene[vehicle_index].state)
     if fore.ind != nothing
-        headway, v_oth = fore.Δs, scene[fore.ind].state.v
+        headway, v_oth = fore.Δs, vel(scene[fore.ind].state)
     else
         headway, v_oth = NaN, NaN
     end

--- a/src/behaviors/tim_lane_changer.jl
+++ b/src/behaviors/tim_lane_changer.jl
@@ -59,7 +59,7 @@ function observe!(model::TimLaneChanger, scene::Frame{Entity{S, D, I}}, roadway:
     vehicle_index = findfirst(egoid, scene)
 
     veh_ego = scene[vehicle_index]
-    v = veh_ego.state.v
+    v = vel(veh_ego.state)
 
     left_lane_exists = convert(Float64, get(N_LANE_LEFT, rec, roadway, vehicle_index)) > 0
     right_lane_exists = convert(Float64, get(N_LANE_RIGHT, rec, roadway, vehicle_index)) > 0
@@ -72,7 +72,7 @@ function observe!(model::TimLaneChanger, scene::Frame{Entity{S, D, I}}, roadway:
     model.dir = DIR_MIDDLE
     if fore_M.Δs < model.threshold_fore # there is a lead vehicle
         veh_M = scene[fore_M.ind]
-        speed_M = veh_M.state.v
+        speed_M = vel(veh_M.state)
         if speed_M ≤ min(model.v_des, v) # they are driving slower than we want
 
             speed_ahead = speed_M
@@ -81,19 +81,19 @@ function observe!(model::TimLaneChanger, scene::Frame{Entity{S, D, I}}, roadway:
             if right_lane_exists &&
                fore_R.Δs > model.threshold_lane_change_gap_rear && # there is space rear
                rear_R.Δs > model.threshold_lane_change_gap_fore && # there is space fore
-               (rear_R.ind == nothing || scene[rear_R.ind].state.v ≤ v) && # we are faster than any follower
-               (fore_R.ind == nothing || scene[fore_R.ind].state.v > speed_ahead) # lead is faster than current speed
+               (rear_R.ind == nothing || vel(scene[rear_R.ind].state) ≤ v) && # we are faster than any follower
+               (fore_R.ind == nothing || vel(scene[fore_R.ind].state) > speed_ahead) # lead is faster than current speed
 
-                speed_ahead = fore_R.ind != nothing ? scene[fore_R.ind].state.v : Inf
+                speed_ahead = fore_R.ind != nothing ? vel(scene[fore_R.ind].state) : Inf
                 model.dir = DIR_RIGHT
             end
             if left_lane_exists &&
                fore_L.Δs > model.threshold_lane_change_gap_rear && # there is space rear
                rear_L.Δs > model.threshold_lane_change_gap_fore && # there is space fore
-               (rear_L.ind == nothing || scene[rear_L.ind].state.v ≤ v) && # we are faster than any follower
-               (fore_L.ind == nothing || scene[fore_L.ind].state.v > speed_ahead) # lead is faster than current speed
+               (rear_L.ind == nothing || vel(scene[rear_L.ind].state) ≤ v) && # we are faster than any follower
+               (fore_L.ind == nothing || vel(scene[fore_L.ind].state) > speed_ahead) # lead is faster than current speed
 
-                speed_ahead = fore_L.ind != nothing ? scene[fore_L.ind].state.v : Inf
+                speed_ahead = fore_L.ind != nothing ? vel(scene[fore_L.ind].state) : Inf
                 model.dir = DIR_LEFT
             end
         end

--- a/src/collision-checkers/minkowski.jl
+++ b/src/collision-checkers/minkowski.jl
@@ -381,23 +381,23 @@ function _bounding_radius(veh::Entity{S,D,I}) where {S,D<:AbstractAgentDefinitio
 end
 
 """
-    is_potentially_colliding(A::Entity{VehicleState,D,I}, B::Entity{VehicleState,D,I}) where {D<:AbstractAgentDefinition,I} 
+    is_potentially_colliding(A::Entity{S,D,I}, B::Entity{S,D,I}) where {S,D<:AbstractAgentDefinition,I} 
 A fast collision check to remove things clearly not colliding
 """
-function is_potentially_colliding(A::Entity{VehicleState,D,I}, B::Entity{VehicleState,D,I}) where {D<:AbstractAgentDefinition,I} 
-    Δ² = normsquared(VecE2(A.state.posG - B.state.posG))
+function is_potentially_colliding(A::Entity{S,D,I}, B::Entity{S,D,I}) where {S, D<:AbstractAgentDefinition,I} 
+    Δ² = normsquared(VecE2(posg(A.state) - posg(B.state)))
     r_a = _bounding_radius(A)
     r_b = _bounding_radius(B)
     Δ² ≤ r_a*r_a + 2*r_a*r_b + r_b*r_b
 end
 
 """
-    is_colliding(A::Entity{VehicleState,D,I}, B::Entity{VehicleState,D,I}, mem::CPAMemory=CPAMemory()) where {D<:AbstractAgentDefinition,I} 
+    is_colliding(A::Entity{S,D,I}, B::Entity{S,D,I}, mem::CPAMemory=CPAMemory()) where {D<:AbstractAgentDefinition,I} 
 returns true if the vehicles A and B are colliding. It uses Minkowski sums.
     is_colliding(mem::CPAMemory)
 returns true if vehA and vehB in mem collides.
 """
-function is_colliding(A::Entity{VehicleState,D,I}, B::Entity{VehicleState,D,I}, mem::CPAMemory=CPAMemory()) where {D<:AbstractAgentDefinition,I} 
+function is_colliding(A::Entity{S,D,I}, B::Entity{S,D,I}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I} 
     if is_potentially_colliding(A, B)
         to_oriented_bounding_box!(mem.vehA, A)
         to_oriented_bounding_box!(mem.vehB, B)
@@ -408,10 +408,10 @@ end
 is_colliding(mem::CPAMemory) = is_colliding(mem.vehA, mem.vehB, mem.mink)
 
 """
-    Vec.get_distance(A::Entity{VehicleState,D,I}, B::Entity{VehicleState,D,I}, mem::CPAMemory=CPAMemory()) where {D<:AbstractAgentDefinition,I} 
+    Vec.get_distance(A::Entity{S,D,I}, B::Entity{S,D,I}, mem::CPAMemory=CPAMemory()) where {D<:AbstractAgentDefinition,I} 
 returns the euclidean distance between A and B.
 """
-function Vec.get_distance(A::Entity{VehicleState,D,I}, B::Entity{VehicleState,D,I}, mem::CPAMemory=CPAMemory()) where {D<:AbstractAgentDefinition,I} 
+function Vec.get_distance(A::Entity{S,D,I}, B::Entity{S,D,I}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I} 
     to_oriented_bounding_box!(mem.vehA, A)
     to_oriented_bounding_box!(mem.vehB, B)
     get_distance(mem)
@@ -435,10 +435,10 @@ struct CollisionCheckResult
 end
 
 """
-    get_first_collision(scene::EntityFrame{S,D,I}, target_index::Int, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
+    get_first_collision(scene::EntityFrame{S,D,I}, target_index::Int, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
 Loops through the scene and finds the first collision between a vehicle and scene[target_index]
 """
-function get_first_collision(scene::EntityFrame{S,D,I}, target_index::Int, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
+function get_first_collision(scene::EntityFrame{S,D,I}, target_index::Int, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
     A = target_index
     vehA = scene[A]
     to_oriented_bounding_box!(mem.vehA, vehA)
@@ -455,10 +455,10 @@ function get_first_collision(scene::EntityFrame{S,D,I}, target_index::Int, mem::
 end
 
 """
-    get_first_collision(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
+    get_first_collision(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
 Loops through the scene and finds the first collision between any two vehicles in `vehicle_indeces`.
 """
-function get_first_collision(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
+function get_first_collision(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
 
     N = length(vehicle_indeces)
     for (a,A) in enumerate(vehicle_indeces)
@@ -479,17 +479,17 @@ function get_first_collision(scene::EntityFrame{S,D,I}, vehicle_indeces::Abstrac
     CollisionCheckResult(false, 0, 0)
 end
 """
-    get_first_collision(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
+    get_first_collision(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
 Loops through the scene and finds the first collision between any two vehicles
 """
-get_first_collision(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I} = get_first_collision(scene, 1:length(scene), mem)
+get_first_collision(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I} = get_first_collision(scene, 1:length(scene), mem)
 
 """
-    is_collision_free(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
-    is_collision_free(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I}
+    is_collision_free(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
+    is_collision_free(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I}
 Check that there is no collisions between any two vehicles in `scene`
 
 If `vehicle_indeces` is used, it only checks for vehicles within `scene[vehicle_indeces]`
 """
-is_collision_free(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I} = !(get_first_collision(scene, mem).is_colliding)
-is_collision_free(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S<:VehicleState,D<:AbstractAgentDefinition,I} = get_first_collision(scene, vehicle_indeces, mem).is_colliding
+is_collision_free(scene::EntityFrame{S,D,I}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I} = !(get_first_collision(scene, mem).is_colliding)
+is_collision_free(scene::EntityFrame{S,D,I}, vehicle_indeces::AbstractVector{Int}, mem::CPAMemory=CPAMemory()) where {S,D<:AbstractAgentDefinition,I} = get_first_collision(scene, vehicle_indeces, mem).is_colliding

--- a/src/collision-checkers/parallel_axis.jl
+++ b/src/collision-checkers/parallel_axis.jl
@@ -1,23 +1,23 @@
 """
-    collision_checker(veh_a::Vehicle, veh_b::Vehicle)
-    collision_checker(veh_a::VehicleState, veh_b::VehicleState, veh_a_def::AbstractAgentDefinition, veh_b_def::AbstractAgentDefinition)
+    collision_checker(veh_a::Entity, veh_b::Entity)
+    collision_checker(veh_a, veh_b, veh_a_def::AbstractAgentDefinition, veh_b_def::AbstractAgentDefinition)
 return True if `veh_a` and `veh_b` collides.
 Relies on the parallel axis theorem.
 """
-function collision_checker(veh_a::Entity{VehicleState, D, I}, veh_b::Entity{VehicleState, D, I}) where {D<:AbstractAgentDefinition, I}
+function collision_checker(veh_a::Entity, veh_b::Entity)
     return collision_checker(veh_a.state, veh_b.state, veh_a.def, veh_b.def)
 end
 
-function collision_checker(veh_a::VehicleState, veh_b::VehicleState, veh_a_def::AbstractAgentDefinition, veh_b_def::AbstractAgentDefinition)
-    center_a = veh_a.posG
-    center_b = veh_b.posG
+function collision_checker(veh_a, veh_b, veh_a_def::AbstractAgentDefinition, veh_b_def::AbstractAgentDefinition) 
+    center_a = posg(veh_a)
+    center_b = posg(veh_b)
     l_a = length(veh_a_def)
     w_a = width(veh_a_def)
     l_b = length(veh_b_def)
     w_b = width(veh_b_def)
     # first fast check:
     @fastmath begin
-        Δ = sqrt((veh_a.posG.x - veh_b.posG.x)^2 + (veh_a.posG.y - veh_b.posG.y)^2)
+        Δ = sqrt((posg(veh_a).x - posg(veh_b).x)^2 + (posg(veh_a).y - posg(veh_b).y)^2)
         r_a = sqrt(l_a*l_a/4 + w_a*w_a/4)
         r_b = sqrt(l_b*l_b/4 + w_b*w_b/4)
     end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,4 @@
+@deprecate get_vel_s velf(state).s
+@deprecate get_vel_t velf(state).t
+
+@deprecate propagate(veh, state, roadway, Δt) propagate(veh, state, a, roadway, Δt)

--- a/src/feature-extraction/features.jl
+++ b/src/feature-extraction/features.jl
@@ -1,26 +1,26 @@
-function Base.get(::Feature_PosFs, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
-    FeatureValue(rec[pastframe][vehicle_index].state.posF.s)
+function Base.get(::Feature_PosFs, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
+    FeatureValue(posf(rec[pastframe][vehicle_index].state).s)
 end
-function Base.get(::Feature_PosFt, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
-    FeatureValue(rec[pastframe][vehicle_index].state.posF.t)
+function Base.get(::Feature_PosFt, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
+    FeatureValue(posf(rec[pastframe][vehicle_index].state).t)
 end
-function Base.get(::Feature_PosFyaw, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
-    FeatureValue(rec[pastframe][vehicle_index].state.posF.ϕ)
+function Base.get(::Feature_PosFyaw, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
+    FeatureValue(posf(rec[pastframe][vehicle_index].state).ϕ)
 end
-function Base.get(::Feature_Speed, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
-    FeatureValue(rec[pastframe][vehicle_index].state.v)
+function Base.get(::Feature_Speed, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
+    FeatureValue(vel(rec[pastframe][vehicle_index].state))
 end
-function Base.get(::Feature_VelFs, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
+function Base.get(::Feature_VelFs, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
     veh = rec[pastframe][vehicle_index]
-    FeatureValue(veh.state.v*cos(veh.state.posF.ϕ))
+    FeatureValue(velf(veh.state).s)
 end
-function Base.get(::Feature_VelFt, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
+function Base.get(::Feature_VelFt, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
     veh = rec[pastframe][vehicle_index]
-    FeatureValue(veh.state.v*sin(veh.state.posF.ϕ))
+    FeatureValue(velf(veh.state).t)
 end
 
 generate_feature_functions("TurnRateG", :turnrateG, Float64, "rad/s")
-function Base.get(::Feature_TurnRateG, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0; frames_back::Int=1) where {S<:VehicleState,D,I,R}
+function Base.get(::Feature_TurnRateG, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0; frames_back::Int=1) where {S,D,I,R}
 
     id = rec[pastframe][vehicle_index].id
 
@@ -32,8 +32,8 @@ function Base.get(::Feature_TurnRateG, rec::EntityQueueRecord{S,D,I}, roadway::R
         veh_index_prev = findfirst(id, rec[pastframe2])
 
         if veh_index_prev != nothing
-            curr = rec[pastframe][veh_index_curr].state.posG.θ
-            past = rec[pastframe2][veh_index_prev].state.posG.θ
+            curr = posg(rec[pastframe][veh_index_curr].state).θ
+            past = posg(rec[pastframe2][veh_index_prev].state).θ
             Δt = get_elapsed_time(rec, pastframe2, pastframe)
             retval = FeatureValue(deltaangle(past, curr) / Δt)
         end
@@ -42,29 +42,29 @@ function Base.get(::Feature_TurnRateG, rec::EntityQueueRecord{S,D,I}, roadway::R
     retval
 end
 generate_feature_functions("TurnRateF", :turnrateF, Float64, "rad/s")
-function Base.get(::Feature_TurnRateF, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
+function Base.get(::Feature_TurnRateF, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
     _get_feature_derivative_backwards(POSFYAW, rec, roadway, vehicle_index, pastframe)
 end
 generate_feature_functions("AngularRateG", :angrateG, Float64, "rad/s²")
-function Base.get(::Feature_AngularRateG, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
+function Base.get(::Feature_AngularRateG, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
     _get_feature_derivative_backwards(TURNRATEG, rec, roadway, vehicle_index, pastframe)
 end
 generate_feature_functions("AngularRateF", :angrateF, Float64, "rad/s²")
-function Base.get(::Feature_AngularRateF, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S<:VehicleState,D,I,R}
+function Base.get(::Feature_AngularRateF, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0) where {S,D,I,R}
     _get_feature_derivative_backwards(TURNRATEF, rec, roadway, vehicle_index, pastframe)
 end
 generate_feature_functions("DesiredAngle", :desang, Float64, "rad")
 function Base.get(::Feature_DesiredAngle, rec::EntityQueueRecord{S,D,I}, roadway::R, vehicle_index::Int, pastframe::Int=0; 
     kp_desired_angle::Float64 = 1.0,
-    ) where {S<:VehicleState,D,I,R}
+    ) where {S,D,I,R}
 
     retval = FeatureValue(0.0, FeatureState.INSUF_HIST)
     if pastframe_inbounds(rec, pastframe) && pastframe_inbounds(rec, pastframe-1)
 
         id = rec[pastframe][vehicle_index].id
 
-        pastϕ = get_state(rec, id, pastframe-1).posF.ϕ
-        currϕ = get_state(rec, id, pastframe).posF.ϕ
+        pastϕ = posf(get_state(rec, id, pastframe-1)).ϕ
+        currϕ = posf(get_state(rec, id, pastframe)).ϕ
 
         Δt = rec.timestep
         expconst = exp(-kp_desired_angle*Δt)
@@ -88,9 +88,9 @@ function Base.get(::Feature_MarkerDist_Left_Left, rec::SceneRecord, roadway::Roa
     =#
 
     veh = rec[pastframe][vehicle_index]
-    lane = roadway[veh.state.posF.roadind.tag]
+    lane = get_lane(roadway, veh)
     if n_lanes_left(lane, roadway) > 0
-        offset = veh.state.posF.t
+        offset = posf(veh.state).t
         lane_left = roadway[LaneTag(lane.tag.segment, lane.tag.lane + 1)]
         FeatureValue(lane.width/2 - offset + lane_left.width)
     else
@@ -104,9 +104,9 @@ function Base.get(::Feature_MarkerDist_Right_Right, rec::SceneRecord, roadway::R
     =#
 
     veh = rec[pastframe][vehicle_index]
-    lane = roadway[veh.state.posF.roadind.tag]
+    lane = get_lane(roadway, veh)
     if n_lanes_right(lane, roadway) > 0
-        offset = veh.state.posF.t
+        offset = posf(veh.state).t
         lane_right = roadway[LaneTag(lane.tag.segment, lane.tag.lane - 1)]
         FeatureValue(lane.width/2 + offset + lane_right.width)
     else
@@ -116,9 +116,9 @@ end
 generate_feature_functions("RoadEdgeDist_Left", :d_edgel, Float64, "m")
 function Base.get(::Feature_RoadEdgeDist_Left, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     veh = rec[pastframe][vehicle_index]
-    offset = veh.state.posF.t
+    offset = posf(veh.state).t
     footpoint = get_footpoint(veh)
-    seg = roadway[veh.state.posF.roadind.tag.segment]
+    seg = roadway[get_lane(roadway, veh.state).tag.segment]
     lane = seg.lanes[end]
     roadproj = proj(footpoint, lane, roadway)
     curvept = roadway[RoadIndex(roadproj)]
@@ -128,9 +128,9 @@ end
 generate_feature_functions("RoadEdgeDist_Right", :d_edger, Float64, "m")
 function Base.get(::Feature_RoadEdgeDist_Right, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     veh = rec[pastframe][vehicle_index]
-    offset = veh.state.posF.t
+    offset = posf(veh.state).t
     footpoint = get_footpoint(veh)
-    seg = roadway[veh.state.posF.roadind.tag.segment]
+    seg = roadway[get_lane(roadway, veh).tag.segment]
     lane = seg.lanes[1]
     roadproj = proj(footpoint, lane, roadway)
     curvept = roadway[RoadIndex(roadproj)]
@@ -140,8 +140,8 @@ end
 generate_feature_functions("LaneOffsetLeft", :posFtL, Float64, "m", can_be_missing=true)
 function Base.get(::Feature_LaneOffsetLeft, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     veh_ego = rec[pastframe][vehicle_index]
-    t = veh_ego.state.posF.t
-    lane = roadway[veh_ego.state.posF.roadind.tag]
+    t = posf(veh_ego.state).t
+    lane = get_lane(roadway, veh_ego)
     if n_lanes_left(lane, roadway) > 0
         lane_left = roadway[LaneTag(lane.tag.segment, lane.tag.lane + 1)]
         lane_offset = t - lane.width/2 - lane_left.width/2
@@ -153,8 +153,8 @@ end
 generate_feature_functions("LaneOffsetRight", :posFtR, Float64, "m", can_be_missing=true)
 function Base.get(::Feature_LaneOffsetRight, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     veh_ego = rec[pastframe][vehicle_index]
-    t = veh_ego.state.posF.t
-    lane = roadway[veh_ego.state.posF.roadind.tag]
+    t = posf(veh_ego.state).t
+    lane = get_lane(roadway, veh_ego)
     if n_lanes_right(lane, roadway) > 0
         lane_right = roadway[LaneTag(lane.tag.segment, lane.tag.lane - 1)]
         lane_offset = t + lane.width/2 + lane_right.width/2
@@ -165,14 +165,14 @@ function Base.get(::Feature_LaneOffsetRight, rec::SceneRecord, roadway::Roadway,
 end
 generate_feature_functions("N_Lane_Right", :n_lane_right, Int, "-", lowerbound=0.0)
 function Base.get(::Feature_N_Lane_Right, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
-    nlr = rec[pastframe][vehicle_index].state.posF.roadind.tag.lane - 1
+    nlr = get_lane(roadway, rec[pastframe][vehicle_index]).tag.lane - 1
     FeatureValue(convert(Float64, nlr))
 end
 generate_feature_functions("N_Lane_Left", :n_lane_left, Int, "-", lowerbound=0.0)
 function Base.get(::Feature_N_Lane_Left, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     veh = rec[pastframe][vehicle_index]
-    seg = roadway[veh.state.posF.roadind.tag.segment]
-    nll = length(seg.lanes) - veh.state.posF.roadind.tag.lane
+    seg = roadway[get_lane(roadway, veh).tag.segment]
+    nll = length(seg.lanes) - get_lane(roadway, veh).tag.lane
     FeatureValue(convert(Float64, nll))
 end
 generate_feature_functions("Has_Lane_Right", :has_lane_right, Bool, "-", lowerbound=0.0, upperbound=1.0)
@@ -188,7 +188,7 @@ end
 generate_feature_functions("LaneCurvature", :curvature, Float64, "1/m", can_be_missing=true)
 function Base.get(::Feature_LaneCurvature, rec::SceneRecord, roadway::Roadway, vehicle_index::Int, pastframe::Int=0)
     veh = rec[pastframe][vehicle_index]
-    curvept = roadway[veh.state.posF.roadind]
+    curvept = roadway[posf(veh.state).roadind]
     val = curvept.k
     if isnan(val)
         FeatureValue(0.0, FeatureState.MISSING)
@@ -322,7 +322,7 @@ function Base.get(::Feature_Speed_Front, rec::SceneRecord, roadway::Roadway, veh
     if neighborfore.ind == nothing
         FeatureValue(0.0, FeatureState.MISSING)
     else
-        FeatureValue(rec[pastframe][neighborfore.ind].state.v)
+        FeatureValue(vel(rec[pastframe][neighborfore.ind].state))
     end
 end
 generate_feature_functions("Timegap", :timegap, Float64, "s", can_be_missing=true)
@@ -331,7 +331,7 @@ function Base.get(::Feature_Timegap, rec::SceneRecord, roadway::Roadway, vehicle
     censor_hi::Float64 = 10.0,
     )
 
-    v = rec[pastframe][vehicle_index].state.v
+    v = vel(rec[pastframe][vehicle_index].state)
 
     if v ≤ 0.0 || neighborfore.ind == nothing
         FeatureValue(censor_hi, FeatureState.CENSORED_HI)
@@ -368,7 +368,7 @@ function Base.get(::Feature_Inv_TTC, rec::SceneRecord, roadway::Roadway, vehicle
         Δs = neighborfore.Δs - len_ego/2 - len_oth/2
 
 
-        Δv = veh_fore.state.v - veh_rear.state.v
+        Δv = vel(veh_fore.state) - vel(veh_rear.state)
 
         if Δs < 0.0 # collision!
             FeatureValue(censor_hi, FeatureState.CENSORED_HI)
@@ -456,7 +456,7 @@ function Base.get(::Feature_Speed_Rear, rec::SceneRecord, roadway::Roadway, vehi
     if neighborrear.ind == nothing
         FeatureValue(0.0, FeatureState.MISSING)
     else
-        FeatureValue(rec[pastframe][neighborrear.ind].state.v)
+        FeatureValue(vel(rec[pastframe][neighborrear.ind].state))
     end
 end
 

--- a/src/feature-extraction/lane_features.jl
+++ b/src/feature-extraction/lane_features.jl
@@ -1,10 +1,10 @@
 """
-    get_lane_width(veh::Vehicle, roadway::Roadway)
+    get_lane_width(veh::Entity, roadway::Roadway)
 Returns the width of the lane where `veh` is.
 """
-function get_lane_width(veh::Entity{VehicleState, D, I}, roadway::Roadway) where {D, I}
+function get_lane_width(veh::Entity, roadway::Roadway)
 
-    lane = roadway[veh.state.posF.roadind.tag]
+    lane = get_lane(roadway, veh.state)
 
     if n_lanes_left(lane, roadway) > 0
         footpoint = get_footpoint(veh)
@@ -16,21 +16,21 @@ function get_lane_width(veh::Entity{VehicleState, D, I}, roadway::Roadway) where
 end
 
 """
-    get_markerdist_left(veh::Vehicle, roadway::Roadway)
+    get_markerdist_left(veh::Entity, roadway::Roadway)
 distance of `veh` to the left marker of the lane
 """
-function get_markerdist_left(veh::Entity{VehicleState, D, I}, roadway::Roadway) where {D, I}
-    t = veh.state.posF.t
+function get_markerdist_left(veh::Entity, roadway::Roadway)
+    t = posf(veh.state).t
     lane_width = get_lane_width(veh, roadway)
     return lane_width/2 - t
 end
 
 """
-    get_markerdist_left(veh::Vehicle, roadway::Roadway)
+    get_markerdist_left(veh::Entity, roadway::Roadway)
 distance of `veh` to the right marker of the lane
 """
-function get_markerdist_right(veh::Entity{VehicleState, D, I}, roadway::Roadway) where {D, I}
-    t = veh.state.posF.t
+function get_markerdist_right(veh::Entity, roadway::Roadway)
+    t = posf(veh.state).t
     lane_width = get_lane_width(veh, roadway)
     return lane_width/2 + t
 end

--- a/src/roadways/frenet.jl
+++ b/src/roadways/frenet.jl
@@ -52,10 +52,10 @@ function _mod2pi2(x::Float64)
 end
 
 """
-    get_posG(frenet::Frenet, roadway::Roadway)
+    posg(frenet::Frenet, roadway::Roadway)
 projects the Frenet position into the global frame
 """
-function get_posG(frenet::Frenet, roadway::Roadway)
+function posg(frenet::Frenet, roadway::Roadway)
     curvept = roadway[frenet.roadind]
     pos = curvept.pos + polar(frenet.t, curvept.pos.θ + π/2)
     VecSE2(pos.x, pos.y, frenet.ϕ + curvept.pos.θ)

--- a/src/states/1d_states.jl
+++ b/src/states/1d_states.jl
@@ -11,6 +11,9 @@ struct State1D
     s::Float64 # position
     v::Float64 # speed [m/s]
 end
+
+vel(s::State1D) = s.v
+
 Base.write(io::IO, ::MIME"text/plain", s::State1D) = @printf(io, "%.16e %.16e", s.s, s.v)
 function Base.read(io::IO, ::MIME"text/plain", ::Type{State1D})
     i = 0

--- a/src/states/interface.jl
+++ b/src/states/interface.jl
@@ -1,0 +1,33 @@
+# Interface to define custom state types
+
+"""
+    posf(state)
+returns the coordinates of the state in the Frenet frame. 
+The return type is expected to be `Frenet`.
+"""
+function posf end
+
+"""
+    posg(state)
+returns the coordinates of the state in the global (world) frame.
+The return type is expected to be a VecSE2.
+"""
+function posg end 
+
+"""
+    vel(state)
+returns the norm of the longitudinal velocity.
+"""
+function vel end
+
+"""
+    velf(state)
+returns the velocity of the state in the Frenet frame.
+"""
+function velf end 
+
+"""
+    velg(state)
+returns the velocity of the state in the global (world) frame.
+"""
+function velg end

--- a/src/states/vehicle_state.jl
+++ b/src/states/vehicle_state.jl
@@ -23,7 +23,13 @@ VehicleState() = VehicleState(VecSE2(), NULL_FRENET, NaN)
 VehicleState(posG::VecSE2{Float64}, v::Float64) = VehicleState(posG, NULL_FRENET, v)
 VehicleState(posG::VecSE2{Float64}, roadway::Roadway, v::Float64) = VehicleState(posG, Frenet(posG, roadway), v)
 VehicleState(posG::VecSE2{Float64}, lane::Lane, roadway::Roadway, v::Float64) = VehicleState(posG, Frenet(posG, lane, roadway), v)
-VehicleState(posF::Frenet, roadway::Roadway, v::Float64) = VehicleState(get_posG(posF, roadway), posF, v)
+VehicleState(posF::Frenet, roadway::Roadway, v::Float64) = VehicleState(posg(posF, roadway), posF, v)
+
+posf(veh::VehicleState) = veh.posF
+posg(veh::VehicleState) = veh.posG
+vel(veh::VehicleState) = veh.v
+velf(veh::VehicleState) = (s=veh.v*cos(veh.posF.ϕ), t=s=veh.v*sin(veh.posF.ϕ))
+velg(veh::VehicleState) = (s=veh.v*cos(veh.posG.θ), t=s=veh.v*sin(veh.posG.θ))
 
 Base.show(io::IO, s::VehicleState) = print(io, "VehicleState(", s.posG, ", ", s.posF, ", ", @sprintf("%.3f", s.v), ")")
 
@@ -72,10 +78,10 @@ get_vel_t(s::VehicleState) = s.v * sin(s.posF.ϕ) # velocity ⟂ to lane
 returns a vehicle state after moving vehstate of a length Δs along its lane.
 """
 function move_along(vehstate::VehicleState, roadway::Roadway, Δs::Float64;
-    ϕ₂::Float64=vehstate.posF.ϕ, t₂::Float64=vehstate.posF.t, v₂::Float64=vehstate.v
+    ϕ₂::Float64=posf(vehstate).ϕ, t₂::Float64=posf(vehstate).t, v₂::Float64=vel(vehstate)
     )
 
-    roadind = move_along(vehstate.posF.roadind, roadway, Δs)
+    roadind = move_along(posf(vehstate).roadind, roadway, Δs)
     try
         footpoint = roadway[roadind]
     catch

--- a/src/states/vehicle_state.jl
+++ b/src/states/vehicle_state.jl
@@ -28,8 +28,8 @@ VehicleState(posF::Frenet, roadway::Roadway, v::Float64) = VehicleState(posg(pos
 posf(veh::VehicleState) = veh.posF
 posg(veh::VehicleState) = veh.posG
 vel(veh::VehicleState) = veh.v
-velf(veh::VehicleState) = (s=veh.v*cos(veh.posF.ϕ), t=s=veh.v*sin(veh.posF.ϕ))
-velg(veh::VehicleState) = (s=veh.v*cos(veh.posG.θ), t=s=veh.v*sin(veh.posG.θ))
+velf(veh::VehicleState) = (s=veh.v*cos(veh.posF.ϕ), t=veh.v*sin(veh.posF.ϕ))
+velg(veh::VehicleState) = (x=veh.v*cos(veh.posG.θ), y=veh.v*sin(veh.posG.θ))
 
 Base.show(io::IO, s::VehicleState) = print(io, "VehicleState(", s.posG, ", ", s.posF, ", ", @sprintf("%.3f", s.v), ")")
 

--- a/test/test_roadways.jl
+++ b/test/test_roadways.jl
@@ -632,7 +632,7 @@ end
     @test isapprox(f.s, 0.0)
     @test f.t == 0.0
     @test f.ϕ == 0.0
-    @test get_posG(f, roadway) == VecSE2(0.0, 0.0, 0.0)
+    @test posg(f, roadway) == VecSE2(0.0, 0.0, 0.0)
     
     lane = roadway[LaneTag(1,1)]
     f = Frenet(lane, 1.0, 0.0, 0.0)

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -41,8 +41,8 @@ end
 
 @testset "VehicleState" begin 
     s = VehicleState(VecSE2(0.0,0.0,0.0), Frenet(NULL_ROADINDEX, 0.0, 0.0, 0.0), 10.0)
-    @test isapprox(get_vel_s(s), 10.0)
-    @test isapprox(get_vel_t(s),  0.0)
+    @test isapprox(velf(s).s, 10.0)
+    @test isapprox(velf(s).t,  0.0)
     show(IOBuffer(), s.posF)
     show(IOBuffer(), s)
 

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -49,6 +49,11 @@ end
     s = VehicleState(VecSE2(0.0,0.0,0.0), Frenet(NULL_ROADINDEX, 0.0, 0.0, 0.1), 10.0)
     @test isapprox(get_vel_s(s), 10.0*cos(0.1))
     @test isapprox(get_vel_t(s), 10.0*sin(0.1))
+    @test isapprox(velf(s).s, 10.0*cos(0.1))
+    @test isapprox(velf(s).t, 10.0*sin(0.1))
+    @test isapprox(velg(s).x, 10.0)
+    @test isapprox(velg(s).y, 0.0)
+    @test isapprox(vel(s), 10.0)
     
     vehdef = VehicleDef(AgentClass.CAR, 5.0, 3.0)
     veh = Vehicle(s, vehdef, 1)


### PR DESCRIPTION
This PR introduces a few functions that define a state interface. 
Instead of using fields: `veh.state.posG`, it uses `posg(veh.state)`

the file `states/interface.jl` has the list of the new functions, they are documented.

Example of how to define a custom state type in the doc.