### PR TITLE
LaneFollowingAction no negative velocities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutomotiveDrivingModels"
 uuid = "99497e54-f3d6-53d3-a3a9-fa9315a7f1ba"
 repo = "https://github.com/sisl/AutomotiveDrivingModels.jl.git"
-version = "0.7.10"
+version = "0.7.11"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/actions/lane_following_accel.jl
+++ b/src/actions/lane_following_accel.jl
@@ -16,7 +16,7 @@ function propagate(veh::Vehicle1D, action::LaneFollowingAccel, roadway::Straight
     s, v = veh.state.s, veh.state.v
 
     s′ = s + v*Δt + a*Δt*Δt/2
-    v′ = maximum((v + a*Δt, 0.))  # no negative velocities
+    v′ = max(v + a*Δt, 0.)  # no negative velocities
 
     s′ = mod_position_to_roadway(s′, roadway)
 
@@ -32,7 +32,7 @@ function propagate(veh::Entity{VehicleState,D,I}, action::LaneFollowingAccel, ro
     ΔT² = ΔT*ΔT
     Δs = ds*ΔT + 0.5*a_lon*ΔT²
 
-    v₂ = maximum((ds + a_lon*ΔT, 0.))  # no negative velocities
+    v₂ = max(ds + a_lon*ΔT, 0.)  # no negative velocities
 
     roadind = move_along(posf(veh.state).roadind, roadway, Δs)
     posG = roadway[roadind].pos

--- a/src/actions/lane_following_accel.jl
+++ b/src/actions/lane_following_accel.jl
@@ -1,6 +1,7 @@
 """
     LaneFollowingAccel
-Longitudinal acceleration
+Longitudinal acceleration.
+The resulting vehicle velocity is capped below at 0 (i.e. standstill). Negative velocities are not allowed.
 
 # Fields
 - `a::Float64` longitudinal acceleration [m/s^2]
@@ -15,7 +16,7 @@ function propagate(veh::Vehicle1D, action::LaneFollowingAccel, roadway::Straight
     s, v = veh.state.s, veh.state.v
 
     s′ = s + v*Δt + a*Δt*Δt/2
-    v′ = v + a*Δt
+    v′ = maximum((v + a*Δt, 0.))  # no negative velocities
 
     s′ = mod_position_to_roadway(s′, roadway)
 
@@ -31,7 +32,7 @@ function propagate(veh::Entity{VehicleState,D,I}, action::LaneFollowingAccel, ro
     ΔT² = ΔT*ΔT
     Δs = ds*ΔT + 0.5*a_lon*ΔT²
 
-    v₂ = ds + a_lon*ΔT
+    v₂ = maximum((ds + a_lon*ΔT, 0.))  # no negative velocities
 
     roadind = move_along(posf(veh.state).roadind, roadway, Δs)
     posG = roadway[roadind].pos


### PR DESCRIPTION
Don't allow vehicle velocities to go below 0. when applying a LaneFollowingActions. Negative velocities correspond to driving backwards and would actually require shifting gears to reverse, which is most likely outside of the scope of this action type. Fixes #43 