### PR TITLE
Moved observe! for LaneFollowingDriver 

### DIFF
--- a/src/behaviors/lane_following_drivers.jl
+++ b/src/behaviors/lane_following_drivers.jl
@@ -16,6 +16,26 @@ function observe!(model::LaneFollowingDriver, scene::Frame{Entity{State1D, D, I}
     return model
 end
 
+function observe!(model::LaneFollowingDriver, scene::Frame{Entity{S, D, I}}, roadway::Roadway, egoid::I) where {S, D, I}
+
+    vehicle_index = findfirst(egoid, scene)
+
+    fore = get_neighbor_fore_along_lane(scene, vehicle_index, roadway, VehicleTargetPointFront(), VehicleTargetPointRear(), VehicleTargetPointFront())
+
+    v_ego = vel(scene[vehicle_index].state)
+    v_oth = NaN
+    headway = NaN
+
+    if fore.ind != nothing
+        v_oth = vel(scene[fore.ind].state)
+        headway = fore.Δs
+    end
+
+    track_longitudinal!(model, v_ego, v_oth, headway)
+
+    return model
+end
+
 mutable struct StaticLaneFollowingDriver <: LaneFollowingDriver
     a::LaneFollowingAccel
 end

--- a/src/behaviors/lat_lon_separable_driver.jl
+++ b/src/behaviors/lat_lon_separable_driver.jl
@@ -5,26 +5,6 @@ end
 
 LatLonSeparableDriver(mlat::LateralDriverModel, mlon::LaneFollowingDriver) = LatLonSeparableDriver{LatLonAccel}(mlat, mlon)
 
-function observe!(model::LaneFollowingDriver, scene::Frame{Entity{S, D, I}}, roadway::Roadway, egoid::I) where {S, D, I}
-
-    vehicle_index = findfirst(egoid, scene)
-
-    fore = get_neighbor_fore_along_lane(scene, vehicle_index, roadway, VehicleTargetPointFront(), VehicleTargetPointRear(), VehicleTargetPointFront())
-
-    v_ego = vel(scene[vehicle_index].state)
-    v_oth = NaN
-    headway = NaN
-
-    if fore.ind != nothing
-        v_oth = vel(scene[fore.ind].state)
-        headway = fore.Δs
-    end
-
-    track_longitudinal!(model, v_ego, v_oth, headway)
-
-    return model
-end
-
 get_name(model::LatLonSeparableDriver) = @sprintf("%s + %s", get_name(model.mlat), get_name(model.mlon))
 function set_desired_speed!(model::LatLonSeparableDriver, v_des::Float64)
     set_desired_speed!(model.mlon, v_des)


### PR DESCRIPTION
Fixes #49. Moved observe! for LaneFollowingDriver from lat_lon_separable_driver.jl to lane_following_drivers.jl so that it is easier to find.